### PR TITLE
fix(api): prevent duplicate registration of dev routes

### DIFF
--- a/apps/api/src/dev-tools.test.ts
+++ b/apps/api/src/dev-tools.test.ts
@@ -1,0 +1,19 @@
+import { describe, it } from 'vitest';
+import Fastify from 'fastify';
+import devToolsRoutes from './routes/dev-tools';
+
+// Ensure dev routes can be registered multiple times without duplication errors
+// when the server is started and stopped (e.g., during hot reload).
+describe('dev tools routes', () => {
+  it('boots server twice without duplicate route errors', async () => {
+    const boot = async () => {
+      const app = Fastify();
+      await app.register(devToolsRoutes);
+      await app.ready();
+      await app.close();
+    };
+
+    await boot();
+    await boot();
+  });
+});

--- a/apps/api/src/routes/dev-tools.ts
+++ b/apps/api/src/routes/dev-tools.ts
@@ -1,0 +1,28 @@
+import { FastifyInstance } from "fastify";
+
+export default async function devToolsRoutes(app: FastifyInstance) {
+  // TEMP: DB introspection (hidden from docs) – BigInt-safe
+  app.get(
+    "/__db",
+    { schema: { hide: true } },
+    async () => {
+      const coerce = (row: Record<string, unknown>) =>
+        Object.fromEntries(
+          Object.entries(row).map(([k, v]) => [k, typeof v === "bigint" ? v.toString() : v])
+        );
+
+      const dbs = await app.prisma.$queryRaw<
+        Array<Record<string, unknown>>
+      >`PRAGMA database_list;`;
+
+      const tables = await app.prisma.$queryRaw<
+        Array<Record<string, unknown>>
+      >`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`;
+
+      return { dbs: dbs.map(coerce), tables: tables.map(coerce) };
+    }
+  );
+
+  // Debug helpers
+  app.get("/__routes", { schema: { hide: true } }, async () => app.printRoutes());
+}


### PR DESCRIPTION
## Summary
- move dev/diagnostic routes into a `dev-tools` plugin
- register dev routes only when `NODE_ENV` is not production
- add regression test to boot server twice without duplicate route errors

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689acee24fdc8325a71c5ad80b4738ee