### PR TITLE
feat(api,db): Lift Unit mint request flow (off-chain approvals, exec stub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This variant runs **entirely without Docker**. Prisma uses SQLite so you can develop anywhere.
 
 ## Quickstart (macOS / no Docker)
+
 1. Copy `.env.sample` → `.env` (the default `DATABASE_URL` points to `packages/db/prisma/dev.db`).
 2. Install deps: `pnpm i`
 3. Generate Prisma client: `pnpm db:generate`
@@ -11,5 +12,21 @@ This variant runs **entirely without Docker**. Prisma uses SQLite so you can dev
 6. Run tests: `pnpm test`
 
 ## Switching to Postgres later
+
 - Change `packages/db/prisma/schema.prisma` datasource to `postgresql` and set `DATABASE_URL` accordingly.
 - Re-run `pnpm db:generate && pnpm db:migrate`.
+
+## Mint Request Flow
+
+Authenticated users (via the fake `/siwe` endpoint) can request token mints which go
+through an off-chain approval process:
+
+1. `POST /mint-requests` – create a new `PENDING` request.
+2. `GET /mint-requests?mine=1` – list your own requests (filter by status with `status=`).
+3. `POST /mint-requests/:id/approve` – admin only; marks request `APPROVED`.
+4. `POST /mint-requests/:id/reject` – reject a pending request.
+5. `POST /mint-requests/:id/execute` – admin only; simulates on-chain execution and
+   returns a fake transaction hash. Execution is blocked unless `ALLOW_EXECUTE=true`
+   is set in the environment.
+
+Requests move from `PENDING` → `APPROVED` → `EXECUTED` or end in `REJECTED`/`CANCELED`.

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -1,0 +1,64 @@
+import fp from "fastify-plugin";
+import { z } from "zod";
+import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+export interface SessionUser {
+  id: string;
+  address: string;
+  isAdmin: boolean;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    user?: SessionUser;
+  }
+  interface FastifyInstance {
+    authenticate: (
+      request: FastifyRequest,
+      reply: FastifyReply,
+    ) => Promise<void>;
+  }
+}
+
+const bodySchema = z.object({
+  address: z.string(),
+  isAdmin: z.boolean().optional(),
+});
+
+export default fp(async function auth(app: FastifyInstance) {
+  app.decorate(
+    "authenticate",
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const raw = request.headers.cookie;
+      const id = raw
+        ?.split(";")
+        .map((c) => c.trim())
+        .find((c) => c.startsWith("session="))
+        ?.split("=")[1];
+      if (!id) {
+        return reply.code(401).send({ error: "Unauthorized" });
+      }
+      const user = await app.prisma.user.findUnique({ where: { id } });
+      if (!user) {
+        return reply.code(401).send({ error: "Unauthorized" });
+      }
+      request.user = user as SessionUser;
+    },
+  );
+
+  app.post("/siwe", { schema: { body: bodySchema } }, async (req, reply) => {
+    const parsed = bodySchema.safeParse(req.body);
+    if (!parsed.success) return reply.code(400).send(parsed.error.flatten());
+    const { address, isAdmin } = parsed.data;
+    const user = await app.prisma.user.upsert({
+      where: { address },
+      update: {
+        lastLoginAt: new Date(),
+        ...(isAdmin !== undefined ? { isAdmin } : {}),
+      },
+      create: { address, isAdmin: isAdmin ?? false },
+    });
+    reply.header("set-cookie", `session=${user.id}; Path=/; HttpOnly`);
+    return { ok: true };
+  });
+});

--- a/apps/api/src/routes/mint-requests.ts
+++ b/apps/api/src/routes/mint-requests.ts
@@ -1,0 +1,171 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { parseMeta } from "../lib/schemas.ts";
+import { randomBytes } from "crypto";
+
+const CreateBody = z.object({
+  tokenId: z.number().int(),
+  amount: z.number().int().positive(),
+  projectId: z.string().optional(),
+  meta: z.record(z.any()).optional(),
+});
+
+const IdParams = z.object({ id: z.string().min(1) });
+
+const ListQuery = z.object({
+  status: z
+    .enum(["PENDING", "APPROVED", "REJECTED", "EXECUTED", "CANCELED"])
+    .optional(),
+  mine: z.coerce.number().int().optional(),
+});
+
+const parseMaybeJSON = (v: unknown) => {
+  if (typeof v !== "string") return v as any;
+  try {
+    return JSON.parse(v);
+  } catch {
+    return v as any;
+  }
+};
+
+export default async function routes(app: FastifyInstance) {
+  if (!("prisma" in app) || !app.prisma) {
+    throw new Error("Prisma plugin not registered");
+  }
+
+  // create
+  app.post(
+    "/mint-requests",
+    { preHandler: app.authenticate, schema: { body: CreateBody } },
+    async (req, reply) => {
+      const parsed = CreateBody.safeParse(req.body);
+      if (!parsed.success) return reply.code(400).send(parsed.error.flatten());
+      const metaStr =
+        parsed.data.meta !== undefined
+          ? JSON.stringify(parseMeta(parsed.data.meta))
+          : undefined;
+      const created = await app.prisma.mintRequest.create({
+        data: {
+          requesterId: req.user!.id,
+          tokenId: parsed.data.tokenId,
+          amount: parsed.data.amount,
+          projectId: parsed.data.projectId,
+          ...(metaStr ? { meta: metaStr } : {}),
+        },
+      });
+      reply.header("Location", `/mint-requests/${created.id}`);
+      return reply
+        .code(201)
+        .send({ ...created, meta: parseMaybeJSON(created.meta) });
+    },
+  );
+
+  // get by id
+  app.get(
+    "/mint-requests/:id",
+    { preHandler: app.authenticate, schema: { params: IdParams } },
+    async (req, reply) => {
+      const params = IdParams.safeParse(req.params);
+      if (!params.success) return reply.code(400).send({ error: "Invalid id" });
+      const row = await app.prisma.mintRequest.findUnique({
+        where: { id: params.data.id },
+      });
+      if (!row) return reply.code(404).send({ error: "Not found" });
+      return { ...row, meta: parseMaybeJSON(row.meta) };
+    },
+  );
+
+  // list
+  app.get(
+    "/mint-requests",
+    { preHandler: app.authenticate, schema: { querystring: ListQuery } },
+    async (req, reply) => {
+      const query = ListQuery.safeParse(req.query);
+      if (!query.success) return reply.code(400).send(query.error.flatten());
+      const where: any = {};
+      if (query.data.status) where.status = query.data.status;
+      if (query.data.mine === 1) where.requesterId = req.user!.id;
+      const rows = await app.prisma.mintRequest.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+      });
+      return rows.map((r) => ({ ...r, meta: parseMaybeJSON(r.meta) }));
+    },
+  );
+
+  // approve
+  app.post(
+    "/mint-requests/:id/approve",
+    { preHandler: app.authenticate, schema: { params: IdParams } },
+    async (req, reply) => {
+      if (!req.user?.isAdmin)
+        return reply.code(403).send({ error: "Forbidden" });
+      const params = IdParams.safeParse(req.params);
+      if (!params.success) return reply.code(400).send({ error: "Invalid id" });
+      const mr = await app.prisma.mintRequest.findUnique({
+        where: { id: params.data.id },
+      });
+      if (!mr) return reply.code(404).send({ error: "Not found" });
+      if (mr.status !== "PENDING")
+        return reply.code(400).send({ error: "Invalid status" });
+      const updated = await app.prisma.mintRequest.update({
+        where: { id: params.data.id },
+        data: {
+          status: "APPROVED",
+          approvedById: req.user.id,
+          approvedAt: new Date(),
+        },
+      });
+      return { ...updated, meta: parseMaybeJSON(updated.meta) };
+    },
+  );
+
+  // reject
+  app.post(
+    "/mint-requests/:id/reject",
+    { preHandler: app.authenticate, schema: { params: IdParams } },
+    async (req, reply) => {
+      const params = IdParams.safeParse(req.params);
+      if (!params.success) return reply.code(400).send({ error: "Invalid id" });
+      const mr = await app.prisma.mintRequest.findUnique({
+        where: { id: params.data.id },
+      });
+      if (!mr) return reply.code(404).send({ error: "Not found" });
+      if (mr.status !== "PENDING")
+        return reply.code(400).send({ error: "Invalid status" });
+      if (!req.user?.isAdmin && mr.requesterId !== req.user?.id)
+        return reply.code(403).send({ error: "Forbidden" });
+      const updated = await app.prisma.mintRequest.update({
+        where: { id: params.data.id },
+        data: { status: "REJECTED" },
+      });
+      return { ...updated, meta: parseMaybeJSON(updated.meta) };
+    },
+  );
+
+  // execute
+  app.post(
+    "/mint-requests/:id/execute",
+    { preHandler: app.authenticate, schema: { params: IdParams } },
+    async (req, reply) => {
+      if (process.env.ALLOW_EXECUTE !== "true")
+        return reply.code(403).send({ error: "Execution disabled" });
+      if (!req.user?.isAdmin)
+        return reply.code(403).send({ error: "Forbidden" });
+      const params = IdParams.safeParse(req.params);
+      if (!params.success) return reply.code(400).send({ error: "Invalid id" });
+      const mr = await app.prisma.mintRequest.findUnique({
+        where: { id: params.data.id },
+      });
+      if (!mr) return reply.code(404).send({ error: "Not found" });
+      if (mr.status !== "APPROVED")
+        return reply.code(400).send({ error: "Invalid status" });
+      const txHash = "0x" + randomBytes(32).toString("hex");
+      const updated = await app.prisma.mintRequest.update({
+        where: { id: params.data.id },
+        data: { status: "EXECUTED", executedAt: new Date(), txHash },
+      });
+      return { ...updated, meta: parseMaybeJSON(updated.meta) };
+    },
+  );
+}

--- a/apps/api/src/types/env.ts
+++ b/apps/api/src/types/env.ts
@@ -1,8 +1,4 @@
-const required = [
-  'API_PORT',
-  'API_HOST',
-  'DATABASE_URL'
-] as const;
+const required = ["API_PORT", "API_HOST", "DATABASE_URL"] as const;
 
 export function getEnv() {
   for (const key of required) {
@@ -11,9 +7,10 @@ export function getEnv() {
     }
   }
   return {
-    NODE_ENV: process.env.NODE_ENV ?? 'development',
+    NODE_ENV: process.env.NODE_ENV ?? "development",
     API_PORT: Number(process.env.API_PORT ?? 3000),
-    API_HOST: process.env.API_HOST ?? '0.0.0.0',
-    API_CORS_ORIGIN: process.env.API_CORS_ORIGIN ?? '*'
+    API_HOST: process.env.API_HOST ?? "0.0.0.0",
+    API_CORS_ORIGIN: process.env.API_CORS_ORIGIN ?? "*",
+    ALLOW_EXECUTE: process.env.ALLOW_EXECUTE === "true",
   };
 }

--- a/apps/api/tests/mint-requests.test.ts
+++ b/apps/api/tests/mint-requests.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import request from "supertest";
+import {
+  ZodTypeProvider,
+  validatorCompiler,
+  serializerCompiler,
+} from "fastify-type-provider-zod";
+import prismaPlugin from "../src/plugins/prisma.js";
+import auth from "../src/plugins/auth.js";
+import mintRoutes from "../src/routes/mint-requests.js";
+import path from "path";
+
+describe("mint requests flow", () => {
+  const dbPath = path.resolve(__dirname, "../../../packages/db/prisma/dev.db");
+  process.env.DATABASE_URL = `file:${dbPath}`;
+  process.env.ALLOW_EXECUTE = "true";
+
+  const app = Fastify().withTypeProvider<ZodTypeProvider>();
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+
+  beforeAll(async () => {
+    await app.register(cors);
+    await app.register(prismaPlugin);
+    await app.register(auth);
+    await app.register(mintRoutes);
+    await app.ready();
+    await app.prisma.mintRequest.deleteMany();
+    await app.prisma.user.deleteMany();
+  });
+
+  afterAll(() => app.close());
+
+  const siwe = async (address: string, isAdmin = false) => {
+    const res = await request(app.server)
+      .post("/siwe")
+      .send({ address, isAdmin });
+    expect(res.status).toBe(200);
+    return res.headers["set-cookie"][0];
+  };
+
+  it("create → list (mine) → approve (admin) → execute", async () => {
+    const userCookie = await siwe("0x1111111111111111111111111111111111111111");
+    const adminCookie = await siwe(
+      "0x2222222222222222222222222222222222222222",
+      true,
+    );
+
+    const created = await request(app.server)
+      .post("/mint-requests")
+      .set("Cookie", userCookie)
+      .send({ tokenId: 1, amount: 5 });
+    expect(created.status).toBe(201);
+    const id = created.body.id;
+
+    const list = await request(app.server)
+      .get("/mint-requests?mine=1")
+      .set("Cookie", userCookie);
+    expect(list.status).toBe(200);
+    expect(list.body.length).toBe(1);
+    expect(list.body[0].status).toBe("PENDING");
+
+    const approved = await request(app.server)
+      .post(`/mint-requests/${id}/approve`)
+      .set("Cookie", adminCookie);
+    expect(approved.status).toBe(200);
+    expect(approved.body.status).toBe("APPROVED");
+
+    const executed = await request(app.server)
+      .post(`/mint-requests/${id}/execute`)
+      .set("Cookie", adminCookie);
+    expect(executed.status).toBe(200);
+    expect(executed.body.status).toBe("EXECUTED");
+    expect(executed.body.txHash).toMatch(/^0x[0-9a-fA-F]{64}$/);
+  });
+
+  it("reject unauth and non-admin approve/execute wrong status", async () => {
+    const cookie = await siwe("0x3333333333333333333333333333333333333333");
+    const created = await request(app.server)
+      .post("/mint-requests")
+      .set("Cookie", cookie)
+      .send({ tokenId: 2, amount: 3 });
+    const id = created.body.id;
+
+    const unauth = await request(app.server).post("/mint-requests");
+    expect(unauth.status).toBe(401);
+
+    const notAdmin = await request(app.server)
+      .post(`/mint-requests/${id}/approve`)
+      .set("Cookie", cookie);
+    expect(notAdmin.status).toBe(403);
+
+    const wrongStatus = await request(app.server)
+      .post(`/mint-requests/${id}/execute`)
+      .set("Cookie", cookie);
+    expect(wrongStatus.status).toBe(403); // forbidden for non-admin
+
+    const adminCookie = await siwe(
+      "0x4444444444444444444444444444444444444444",
+      true,
+    );
+    const badExec = await request(app.server)
+      .post(`/mint-requests/${id}/execute`)
+      .set("Cookie", adminCookie);
+    expect(badExec.status).toBe(400);
+  });
+});

--- a/packages/db/prisma/migrations/20250812061207_mint_request/migration.sql
+++ b/packages/db/prisma/migrations/20250812061207_mint_request/migration.sql
@@ -1,0 +1,56 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "address" TEXT NOT NULL,
+    "email" TEXT,
+    "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastLoginAt" DATETIME
+);
+
+-- CreateTable
+CREATE TABLE "Project" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "ownerAddress" TEXT,
+    "chainId" INTEGER,
+    "meta" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "MintRequest" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "requesterId" TEXT NOT NULL,
+    "projectId" TEXT,
+    "tokenId" INTEGER NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "meta" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "approvedById" TEXT,
+    "approvedAt" DATETIME,
+    "txHash" TEXT,
+    "executedAt" DATETIME,
+    CONSTRAINT "MintRequest_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "MintRequest_approvedById_fkey" FOREIGN KEY ("approvedById") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_address_key" ON "User"("address");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Project_slug_key" ON "Project"("slug");
+
+-- CreateIndex
+CREATE INDEX "MintRequest_status_idx" ON "MintRequest"("status");
+
+-- CreateIndex
+CREATE INDEX "MintRequest_requesterId_idx" ON "MintRequest"("requesterId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -7,49 +7,86 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model User {
+  id          String    @id @default(cuid())
+  address     String    @unique
+  email       String?   @unique
+  isAdmin     Boolean   @default(false)
+  createdAt   DateTime  @default(now())
+  lastLoginAt DateTime?
+
+  mintRequests MintRequest[] @relation("MintRequestRequester")
+  approvals    MintRequest[] @relation("MintRequestApprover")
+}
+
 model LiftUnit {
-  id           Int      @id @default(autoincrement())
-  externalId   String?  @unique
-  status       String   @default("DRAFT") // was enum LiftUnitStatus
-  quantity     Decimal?
-  unit         String?  // e.g. "LU"
-  meta         String?  // was Json; store stringified JSON
-  issuedAt     DateTime?
-  retiredAt    DateTime?
+  id         Int       @id @default(autoincrement())
+  externalId String?   @unique
+  status     String    @default("DRAFT") // was enum LiftUnitStatus
+  quantity   Decimal?
+  unit       String? // e.g. "LU"
+  meta       String? // was Json; store stringified JSON
+  issuedAt   DateTime?
+  retiredAt  DateTime?
 
-  events       LiftUnitEvent[]
+  events LiftUnitEvent[]
 
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([status])
 }
 
 model LiftUnitEvent {
-  id          Int      @id @default(autoincrement())
-  liftUnitId  Int
-  type        String   // was enum LiftUnitEventType
-  txId        String?
-  payload     String?  // was Json; store stringified JSON
-  meta        String?  // was Json; store stringified JSON
-  eventAt     DateTime @default(now())
+  id         Int      @id @default(autoincrement())
+  liftUnitId Int
+  type       String // was enum LiftUnitEventType
+  txId       String?
+  payload    String? // was Json; store stringified JSON
+  meta       String? // was Json; store stringified JSON
+  eventAt    DateTime @default(now())
 
-  liftUnit    LiftUnit @relation(fields: [liftUnitId], references: [id], onDelete: Cascade)
+  liftUnit LiftUnit @relation(fields: [liftUnitId], references: [id], onDelete: Cascade)
 
-  createdAt   DateTime @default(now())
+  createdAt DateTime @default(now())
 
   @@unique([liftUnitId, type, txId])
   @@index([liftUnitId, type])
 }
 
 model Project {
-  id           Int       @id @default(autoincrement())
+  id           Int      @id @default(autoincrement())
   name         String
-  slug         String    @unique
+  slug         String   @unique
   description  String?
   ownerAddress String?
   chainId      Int?
-  meta         String?   // must be String for SQLite
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+  meta         String? // must be String for SQLite
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}
+
+model MintRequest {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  requesterId String
+  requester   User   @relation("MintRequestRequester", fields: [requesterId], references: [id])
+
+  projectId String?
+  tokenId   Int
+  amount    Int
+  meta      String? // was Json; store stringified JSON
+  status    String  @default("PENDING") // was enum MintStatus
+
+  approvedById String?
+  approvedBy   User?     @relation("MintRequestApprover", fields: [approvedById], references: [id])
+  approvedAt   DateTime?
+
+  txHash     String?
+  executedAt DateTime?
+
+  @@index([status])
+  @@index([requesterId])
 }

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,10 +1,14 @@
-import { prisma } from '../src/index';
+import { prisma } from "../src/index";
 
 async function main() {
   await prisma.user.upsert({
-    where: { address: '0x0000000000000000000000000000000000000000' },
-    update: {},
-    create: { address: '0x0000000000000000000000000000000000000000', email: 'seed@example.com' }
+    where: { address: "0x0000000000000000000000000000000000000000" },
+    update: { isAdmin: true },
+    create: {
+      address: "0x0000000000000000000000000000000000000000",
+      email: "seed@example.com",
+      isAdmin: true,
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
- add `User` and `MintRequest` models with status tracking
- expose mint request REST endpoints with fake SIWE auth and execution stub
- document mint request flow and add tests

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz; RequestAbortedError: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_689ad98515408325b707372e9deaa97e