### PR TITLE
chore(ci): rely on packageManager for pnpm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
         continue-on-error: true
         uses: pnpm/action-setup@v4
         with:
-          version: 9
-          run_install: false
+          run_install: false    # action will use package.json's "packageManager": "pnpm@9.0.0"
 
       - name: Enable pnpm via Corepack (fallback)
         if: steps.setup_pnpm.outcome == 'failure'


### PR DESCRIPTION
## Summary
- drop explicit pnpm version in CI
- rely on package.json's packageManager for pnpm version

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689c29b40d608325ab4aeda04565fdaf